### PR TITLE
P2 identity reconciliation + wire-facts diff (call prep)

### DIFF
--- a/docs/architecture/p2_identity_reconciliation.md
+++ b/docs/architecture/p2_identity_reconciliation.md
@@ -1,0 +1,170 @@
+# P2 identity-layer reconciliation + wire-facts diff
+
+Call-prep for the N8SDR ↔ KD4YAL P2 collaboration (2026-07-20). Two
+parts: (1) fold Jerry's `HardwareCatalog`/`RadioProfile` into our
+`RadioCapabilities`/`RigRegistry` (agreed: one system, ours); (2) diff
+his proven `P2Session` wire facts against our stubbed `ETH` branches.
+
+Both trees local: ours `Y:/Claude local/SDRProject/lyra-cpp`, his fork
+`Y:/Claude local/SDRProject/lyra-cpp-p2saturn`.
+
+---
+
+## Part 1 — identity/capability layers
+
+### The two stacks side by side
+
+| Layer | Jerry (fork) | Ours (multi-rig arc) | Granularity |
+|---|---|---|---|
+| Model/capability | `HardwareCatalog` + `HardwareModelDescriptor` (data table, per **marketed model** "ANAN-G2") | `RadioCapabilities` + `capabilitiesFor(family)` (per **family** enum) | **his is finer** |
+| Per-device identity | `RadioProfile` (per-MAC, JSON) | `RigProfile` + `RigRegistry` (per-MAC, QSettings) | equivalent |
+| Station config | `StationProfile` (JSON: band mem, layout, audio, CAT) | `RigScope` (`rig/<rigId>/…` QSettings) | equivalent |
+| Operating (TX/RX) | keep existing `ProfileManager` | keep existing `ProfileManager` | same — untouched |
+
+### The core mismatch: family vs model
+
+Our `RadioCapabilities` is **per-family** (5 enum values: Hl2 / AnanP1 /
+AnanP2 / BrickP2 / Unknown) and **thin** — protocol, adcBits, LNA range,
+audio path, PS-mod flag. His `HardwareCatalog` is **per-marketed-model**
+and **rich** — per-band PA-gain tables, RX meter/display cal offsets,
+volts/amps telemetry + conversion constants, ADC count, MkII BPF, LR
+audio swap, P2 PS default peak, RX2 stepped atten. Transcribed 1:1 from
+Thetis `clsHardwareSpecific.cs` (authoritative).
+
+Thetis itself separates `comboRadioModel` (marketed model) from the
+discovery board id — because several products share a gateware family
+but need different PA/cal/mic/relay data. **His model granularity is the
+correct one for the calibration data; our family enum is too coarse to
+hold it.** So the reconciliation is *not* "his table folds into our
+struct" — our capability layer has to grow a model tier.
+
+### Recommended unified shape (one system, ours)
+
+1. **Keep `RigRegistry`/`RigProfile` as the identity authority** (per-MAC,
+   QSettings — consistent with the whole app + the backup engine).
+2. **Add a model tier**: adopt his `HardwareCatalog` as the model-detail
+   table (it's just data, transcribed from Thetis — the expensive part is
+   already done and bench-anchored). Our `RadioFamily` stays as the coarse
+   gateware/board bucket; the **model key** ("ANAN-G2") is the fine key.
+3. **`RigProfile` gains a `hardwareModelKey` field** (his `RadioProfile`
+   already has it; ours doesn't — this is the one real schema gap).
+   Discovery seeds it from `defaultModelForBoard(board, protocol2)`;
+   operator can override.
+4. **`capabilitiesFor()` becomes model-aware** — either derived from the
+   catalog row, or kept as the coarse family fallback when no model is
+   set. Existing HL2 callers keep working (HL2 = family Hl2 = model
+   "HERMES-LITE", metadata-only per his retention rule).
+
+### Field map: his `RadioProfile` → our `RigProfile`
+
+| Jerry `RadioProfile` | Our `RigProfile` | Action |
+|---|---|---|
+| `mac` | `mac` | same stable key (ours also derives `rigId = rig_<mac>`) |
+| `nickname` | `label` | same role — rename on import |
+| `lastKnownIp` | `lastIp` | same |
+| `protocol` (1\|2) | (encoded in `family` + `RadioCapabilities.protocol`) | keep ours; drop his explicit field or keep as convenience |
+| `hardwareModelKey` | **(missing)** | **ADD to RigProfile** — the schema gap |
+| `trxAntenna` (1..3) | (missing) | P2-only → per-rig config (`RigScope`) |
+| `audioRoute` ("hl2"/"pc"/"") | machine-local audio (design: per-PC) | reconcile: his is per-profile transient; ours is per-PC. Keep ours; his "seed P2 = pc" rule is sound |
+| `firstSeen`/`lastSeen`/`schemaVersion` | (missing) | optional metadata — cheap to add |
+| — | `rigId`, `family` | ours; his uses mac-as-key + model.expectedBoard |
+
+**Storage divergence:** his = JSON docs (`profiles/radios/<uuid>.json`);
+ours = QSettings (`rigs/<rigId>/`). Unify on **QSettings/RigRegistry**.
+Worth adding a **JSON export/import** later for his Thetis-database
+importer (maps `comboRadioModel`, PA gains, cal, antennas, atten, PS,
+mic, OC, audio devices) — a genuinely useful onboarding feature, not
+core.
+
+**Reserved ordinals (do not reuse):** his catalog reserves upstream
+Thetis `ANAN_G2E = model 16`, board `HermesC10 = 20`. Honor these if we
+extend the enums.
+
+---
+
+## Part 2 — wire-facts diff (his proven vs our stub)
+
+### Our side: essentially nothing proven
+
+`src/wire/Network.cpp` carries **one** `ETH` branch — the P2 arm of the
+`sendProtocol1Samples` loop (`network.c:1237-1341`) — as **commented
+DEFERRED reference text**, tagged "Protocol 2 / ANAN — v0.4 scope." That
+is the *entire* P2 footprint in our tree. No P2 discovery, no control
+packets, no recv path, no phase-word, no port map. P2 is 0% implemented;
+the stub is a placeholder marking where the send-loop branch will go.
+
+### His side: full RX bring-up, bench-verified on a live G2
+
+From `P2Session.h` (both ends of the wire — his radio-side p2app +
+Thetis client — cross-referenced):
+
+- **Discovery** — dual P1+P2 sweep.
+- **Session/controller lease** — radio captures client addr from the
+  general packet (`reply_addr`); HP `run=1` → active, `run=0` → release;
+  ~1 s inactivity timeout (hardware watchdog).
+- **4 control packets** — General (60 B → :1024), DDC-specific,
+  DUC-specific, High-Priority (1444 B → :1027). Full byte offsets
+  documented in the header.
+- **HP status parse** — 60 B ← :1025, 200 ms cadence RX / 1 ms TX /
+  immediate on PTT; PTT bits, ADC overflow, fwd/rev power, FIFO
+  depths, ADC peaks (fw ≥ 27), supply volts, user I/O.
+- **DDS phase-word encoding** — `freq_word = Hz × 2^32 / 122.88 MHz`
+  (radio hardcodes phase-word decode). ⚠ the single most important
+  P2-vs-P1 frequency fact.
+- **Port map** — 1024 general (out), 1025 HP-status (in), 1026 mic (in),
+  1027 HP (out), 1035+n DDC-n IQ (in). One socket; demux by the radio's
+  **source** port.
+- **Control seq ALWAYS ZERO** — only data streams increment; decoders
+  must not dedupe control.
+- **Front-end (Saturn)** — Alex TX/RX words in the HP packet; the CLIENT
+  owns the RF front end. ⚠ **all-zero Alex words = radio connects but is
+  DEAF** (bench trap 2026-07-19).
+- **Bench safety** — RX-only by construction: transmit bit never set,
+  drive 0, PA-enable 0, hardware-watchdog bit on (radio idles ~1 s after
+  client death).
+
+### RX-path compatibility (the good news)
+
+His `P2RxBridge` feeds DDC0 IQ into **router 0 — the identical seam our
+P1 EP6 path dispatches to** (`router_instance(0)` port 0 →
+`WdspEngine::feedIq`), and keeps `HL2Stream` as the tuning/state
+authority (bridge mirrors `rx1FreqChanged` → DDC0). P1/P2 are mutually
+exclusive (single-feeder-thread contract). So **everything downstream —
+WDSP, panadapter, S-meter, audio — is unchanged**, exactly as our
+un-defer-`ETH` plan intended. The DSP/UI seam matches; only the wire
+back-end differs.
+
+### The one open architecture question for the call
+
+His proven RX lives in a standalone `P2Session` (QThread + QUdpSocket).
+Our wire layer is native WinSock + dedicated OS threads + the
+ChannelMaster free-function port. **His own doc says the final should
+complete the ChannelMaster `ETH` branches, not carry a parallel path** —
+i.e. re-home his proven facts into `write_main_loop_p2` / the `ETH`
+branches. Two routes:
+
+- **(A) Adopt `P2Session`/`P2RxBridge` largely as-is** — fastest, it
+  works today, RX on the bench now. Divergent from the wire layer's
+  native-thread/ChannelMaster discipline.
+- **(B) Port his proven facts into the `ETH` branches** — consistent
+  with the wire layer + his stated end-goal; slower.
+
+Recommendation to discuss: **(A) as an immediate bench-working RX for the
+Brick, then converge to (B)** once the facts are locked and the harness
+is green — using his byte-level regression harness as the safety net for
+the port. The wire facts are identical either way; only the plumbing
+moves.
+
+---
+
+## Suggested call agenda
+
+1. Confirm unified identity shape: `RigRegistry` authority + adopt
+   `HardwareCatalog` as the model tier + add `hardwareModelKey` to
+   `RigProfile`.
+2. Route decision: (A)-then-(B) vs straight-(B) for the P2 wire path.
+3. Regression harness: how his Saturn-repo capture harness plugs into
+   our client tests (the strict-p2app property as our correctness gate).
+4. Board coverage: G2 (his) + Brick (Rick) — the Brick has no Saturn
+   front end, so catalog needs a Brick/Hermes-class row (no Alex words).
+5. Process: PR-with-review; where P2 lands (branch/upstream cadence).

--- a/docs/architecture/p2_wire_design.md
+++ b/docs/architecture/p2_wire_design.md
@@ -1,0 +1,197 @@
+# Protocol 2 wire engine — design (BrickSDR2 / ANAN-P2)
+
+Status: **SCOPING / design locked, no code.** Grounds the native
+C++23 HPSDR **Protocol 2** wire engine that lyra-cpp needs to talk to
+Protocol-2 radios — first target the **BrickSDR2 14-bit** (operator's
+unit), forward-compatible with the ANAN G2 / P2 family.
+
+lyra-cpp is Windows-only, C++23 / Qt6. Provenance rule (standing):
+**study the reference, implement Lyra-native, no code copy.** All
+file:line citations below are for study only.
+
+---
+
+## 1. What the reference is (ramdor/Thetis)
+
+Cloned to `D:/sdrprojects/ramdor-Thetis` (the ramdor fork, which has
+Protocol 2, unlike the HermesLite-only path we ported from before).
+
+Thetis's entire P1/P2 wire layer is a **native C library**,
+`ChannelMaster.dll`, with **full GPL source in the repo** at
+`Project Files/Source/ChannelMaster/`. The C# side
+(`Console/HPSDR/NetworkIOImports.cs` — 248 `DllImport`s;
+`clsRadioDiscovery.cs`) is only discovery + orchestration on top; it
+carries **no packet framing**. The authoritative framing lives in:
+
+| File | Role |
+|---|---|
+| `ChannelMaster/network.c` (1494 ln) | UDP sockets, endpoints, discovery, send/recv loops, C&C builders |
+| `ChannelMaster/netInterface.c` (1689 ln) | command/data packet builders, per-field setters |
+| `ChannelMaster/networkproto1.c` | the P1/HL2 path (already our lyra-cpp reference) |
+| `ChannelMaster/network.h` | struct defs, `enum { … ETH = 1 }` (P2), bit fields |
+
+### 1.1 How Thetis structures P1 vs P2 (the key structural finding)
+
+Thetis uses **one engine with a per-radio protocol flag**, not a fork
+and not clean classes:
+
+- `nativeInitMetis(…, int protocol, int model_id, …)` stores the
+  selected protocol (`network.c:84`).
+- A single global/per-radio `RadioProtocol` field carries it
+  (`network.h:452`: `ETH = 1 // Protocol ETH (P2)`).
+- One `ReadThreadMainLoop()` (`network.c:645`) handles both.
+- The shared send/recv/C&C functions branch **inline** on
+  `if (RadioProtocol == ETH) { …P2… } else { …P1… }` at ~8 scattered
+  points (`network.c:909, 1061, 1177, 1246, 1259, 1298, 1372, 1387`).
+
+That inline-conditional style is exactly what we do **not** copy —
+it's the tangle the NO-PATCHING / rewrite-correctly rule exists to
+avoid. See §2.
+
+---
+
+## 2. lyra-cpp architecture decision
+
+**Follow the structure the wire layer already committed to** — which
+is exactly Thetis's: one engine, a `radioProtocol` field, protocol-
+branched code. lyra-cpp's `src/wire/` is a **verbatim reference port**
+of ChannelMaster, and it already carries the pieces:
+
+- `enum class RadioProtocol { USB = 0, ETH = 1 }` and the live global
+  selector `radioProtocol` (`RadioNet.h:159`, `RadioNet.cpp:405`,
+  default `USB` = P1) — the direct mirror of Thetis's `RadioProtocol`
+  shadow variable.
+- The P2 (`ETH`) branches are **already present as DEFERRED reference
+  text** — the wire layer's house discipline is to port ChannelMaster
+  verbatim and carry not-yet-implemented paths as commented reference
+  code tagged `DEFERRED [feature — version]`. `Network.cpp` already
+  holds the `if (radioProtocol == RadioProtocol::ETH)` branches
+  (`network.c:1246-1341`) this way, tagged "Protocol 2 / ANAN is v0.4
+  scope."
+- C&C framing lives in `FrameComposer.h` as free functions over the
+  global `radionet` (`write_main_loop_hl2()`, `set_rx_freq()`,
+  `set_tx_freq()`, `set_pa_on()`, …) — the P1 counterpart of Thetis's
+  `WriteMainLoop_HL2` / `netInterface.c` setters.
+
+So P2 is **not** a new polymorphic engine and **not** a `WireEngine`
+interface — imposing either would be a rewrite against an already-
+reference-faithful structure (and against the standing
+reference-fidelity discipline). P2 = **un-defer the `ETH` branches and
+fill the missing P2 units**, driven by the existing `radioProtocol`
+selector.
+
+> Course-correction note: an earlier draft of this doc proposed a
+> `WireEngine` interface with P1/P2 implementations. That was wrong for
+> this codebase — the grounding read showed the wire layer had already
+> adopted Thetis's protocol-field-branch structure with the ETH path
+> stubbed as deferred reference text. We follow that.
+
+**What's genuinely missing (the P2 work):**
+
+- **P2 discovery** — `hl2_discovery.{h,cpp}` is P1-specific (63-byte
+  probe → :1024 broadcast). P2 discovery is a different packet; add it
+  either as a `radioProtocol`-branch in the discovery path or a P2
+  sibling that populates the same `RigRegistry`/`RadioCapabilities`.
+- **P2 C&C composer** — a `write_main_loop_p2()` (or the un-deferred
+  `ETH` branches in the shared composer) mirroring Thetis's P2 general
+  (1024) + high-priority (1025) command build in `netInterface.c`.
+- **P2 RX/TX data plane** — the DDC IQ recv + DUC TX paths, un-deferred
+  from the `ETH` branches in `Network.cpp` / the recv thread.
+
+**Selection wiring** — `RadioCapabilities.protocol`
+(`src/rig/RadioCapabilities.h:62`, `1|2`) from the active `RigProfile`
+sets `radioProtocol` at connect-time. Today it always resolves to
+`USB`/P1; a BrickP2/AnanP2 rig sets it to `ETH`.
+
+`HL2Stream` stays the Qt-facing `QObject` operator surface; the P2
+branches live below it in the wire layer, exactly as the P1 code does.
+Plugs into the rig layer already built: `RigRegistry` (MAC identity),
+`RadioCapabilities` (`AnanP2`/`BrickP2`, `protocol=2`, `adcBits=14`),
+`RigScope` (per-rig config).
+
+---
+
+## 3. Protocol 2 wire facts (from `network.c` / `netInterface.c`)
+
+The data a `NetworkProto2` unit must implement. **To be filled to
+byte-level at implementation time** — this is the endpoint/plane map,
+not the final packing spec.
+
+### 3.1 UDP endpoints
+
+| Port | Dir | Purpose (Thetis) |
+|---|---|---|
+| **1024** | host→radio | General C&C (`CmdGeneral`, `network.c:821`) |
+| **1025** | both | Rx-specific C&C + **60-byte High-Priority C&C** (`CmdRx`; `SendHighPriority`; recv `network.c:519` "60 bytes - High Priority C&C data") |
+| **1026** | host→radio | DUC / TX (audio + TX-IQ) — to confirm at impl time |
+| **1027** | radio→host | 16-bit raw ADC data, 1024-byte frames (`network.c:774`) |
+| (DDC data ports) | radio→host | per-DDC RX IQ streams — enumerate at impl time |
+
+`p2_custom_port_base` handling (`network.c:112` = 1025) + a
+`p2hw_uses_different_ports` init flag exist — some P2 hardware remaps
+ports; capture that as a capability, not a hardcode.
+
+### 3.2 Discovery
+
+Discovery reply carries **`MACAddr` (6 B)**, **`fwCodeVersion`**,
+**`BoardType`** (`network.c:349-359`). BoardType → `RadioFamily`
+(`familyForBoardId` already stubbed; add the P2 board ids —
+BrickSDR2 ≈ ANAN-10E-class). MAC → `RigRegistry` id (already the
+MAC-keyed scheme). This is the identity source for the Rig picker.
+
+### 3.3 Data / control planes to build
+
+1. **Discovery** — broadcast probe, parse reply → capabilities + rig
+   identity.
+2. **RX data plane** — DDC configuration + per-DDC IQ recv → feed the
+   existing WDSP RX chain (same sink the HL2 path uses).
+3. **C&C control plane** — general (1024) + 60-byte high-priority
+   (1025): freq (DDC LO), sample rate, LNA/gain, MOX.
+4. **TX / DUC plane** — high-priority TX + DUC (1026): TX-IQ + audio,
+   PA/drive. Gated behind the same default-OFF PA discipline as the
+   HL2 TX work.
+
+---
+
+## 4. Staged build order
+
+Each stage is a small, independently benchable commit — mirrors the
+multi-rig config staging. RX before TX; TX gated behind default-OFF PA.
+
+| Stage | Deliverable | Bench gate |
+|---|---|---|
+| **P2-0** | Wire `RadioCapabilities.protocol` → `radioProtocol` at connect (P1 rigs still resolve to `USB`, **no behaviour change**) | HL2 still works identically |
+| **P2-1** | P2 **discovery** → populate `RigProfile` + capabilities | BrickSDR2 appears in Rig picker with correct identity (no RX/TX — inert) |
+| **P2-2** | P2 **RX** — un-defer the DDC config + IQ recv `ETH` branches → WDSP RX | Hear the Brick |
+| **P2-3** | P2 **C&C** — `write_main_loop_p2` / un-deferred composer: freq / rate / gain / MOX | Tune, rate-switch, LNA on the Brick |
+| **P2-4** | P2 **TX / DUC** — un-defer the `ETH` TX branch, default-OFF PA, dummy-load first | Follows the HL2 TX safety-gate ritual |
+
+Each stage un-defers a bounded set of the `ETH` branches already
+carried as reference text. P2-0 is the only stage touching the shared
+selector (a one-line wiring, P1 unchanged); everything after is the P2
+branches, inert for P1 rigs by construction.
+
+---
+
+## 5. Forward-compat / capability notes
+
+- `nddc` / DDC count is P2-family-specific (ANAN G2 = 4, 7000DLE = 7,
+  Brick TBD) — read from capabilities, never hardcode.
+- P2 gives true per-DDC sample-rate independence (unlike HL2 P1's
+  shared wire rate) — the engine must not assume a single global rate.
+- BrickSDR2 capability profile = **Hermes-class** (mic / PTT / input
+  options, **14-bit ADC**) over **Protocol 2**, auto-detected. Timmy's
+  working Thetis config for the Brick uses Radio Model = HERMES with
+  Auto-detect Protocol → P2; the "HERMES model" is the *capability*
+  profile, the wire is P2.
+- One rig at a time (locked earlier) — no simultaneous P1+P2.
+
+---
+
+## 6. Provenance
+
+Study-only references (no code copied into lyra-cpp; GPL-compatible):
+`ramdor/Thetis` `Project Files/Source/ChannelMaster/{network.c,
+netInterface.c, network.h}` for P2 framing; `networkproto1.c` for the
+P1 contrast. WDSP DSP ports remain the only attributed code per the
+project rule.


### PR DESCRIPTION
Planning docs for the Protocol 2 (BrickSDR2 / ANAN) collaboration — shared ahead of the architecture call so we walk in with talking points already marked up.

**Two docs:**

1. **`docs/architecture/p2_wire_design.md`** — the P2 architecture decision: complete the existing `ETH` branches in the reference-faithful ChannelMaster port (driven by the `radioProtocol` selector), rather than a parallel/interface engine. Staged P2-0..P2-4. Reference = ramdor/Thetis ChannelMaster GPL source.

2. **`docs/architecture/p2_identity_reconciliation.md`** — folding the `HardwareCatalog`/`RadioProfile` layers into `RadioCapabilities`/`RigRegistry` (one identity system), plus a wire-facts diff of the proven P2 RX bring-up vs our stubbed `ETH` branches. Ends with a 5-point call agenda.

**Jerry (@kd4yal2024):** please comment inline anywhere you disagree or want to adjust — especially:
- the family-vs-model mapping and the `hardwareModelKey` addition (Part 1),
- route **(A)** adopt `P2Session`/`P2RxBridge` as-is then converge, vs **(B)** straight port into the `ETH` branches (Part 2, "open architecture question"),
- any wire-fact I've mis-stated vs your bench truth.

Docs-only; no code. Not urgent to merge — the value is the review surface before the call.